### PR TITLE
XDR-3685: Update azurerm to support additional tactics

### DIFF
--- a/modules/sentinel-scheduled-alert-rule/README.md
+++ b/modules/sentinel-scheduled-alert-rule/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.34 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.34 |
 
 ## Resources
 

--- a/modules/sentinel-scheduled-alert-rule/main.tf
+++ b/modules/sentinel-scheduled-alert-rule/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.0"
+      version = "~> 3.34"
     }
   }
   required_version = ">= 0.12.26"


### PR DESCRIPTION
Updating azurerm to support additional tactics
https://registry.terraform.io/providers/hashicorp/azurerm/3.34.0/docs/resources/sentinel_alert_rule_scheduled
