### PR TITLE
XDR-7734: Update azurerm provider to >= 4.54 (feat)

### DIFF
--- a/modules/sentinel-library-rule/README.md
+++ b/modules/sentinel-library-rule/README.md
@@ -3,14 +3,14 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.42 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.54 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.42 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 4.54 |
 
 ## Resources
 

--- a/modules/sentinel-library-rule/main.tf
+++ b/modules/sentinel-library-rule/main.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 1.2"
+  required_version = ">= 1.5"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.42"
+      version = ">= 4.54"
     }
   }
 }
@@ -36,18 +36,18 @@ resource "azurerm_sentinel_alert_rule_scheduled" "rule" {
   custom_details             = try(lookup(local.rule_data, "customDetails", {}), {})
 
 
-  dynamic "incident_configuration" {
+  dynamic "incident" {
     for_each = local.create_incident == null ? [] : ["enabled"]
     content {
-      create_incident = local.create_incident
+      create_incident_enabled = local.create_incident
       grouping {
         enabled                 = lookup(local.create_incident_grouping, "enabled", null)
         lookback_duration       = lookup(local.create_incident_grouping, "lookbackDuration", null)
         reopen_closed_incidents = lookup(local.create_incident_grouping, "reopenClosedIncidents", null)
         entity_matching_method  = lookup(local.create_incident_grouping, "entityMatchingMethod", "AnyAlert")
-        group_by_entities       = lookup(local.create_incident_grouping, "groupByEntities", [])
-        group_by_alert_details  = lookup(local.create_incident_grouping, "groupByAlertDetails", [])
-        group_by_custom_details = lookup(local.create_incident_grouping, "groupByCustomDetails", [])
+        by_entities             = lookup(local.create_incident_grouping, "groupByEntities", [])
+        by_alert_details        = lookup(local.create_incident_grouping, "groupByAlertDetails", [])
+        by_custom_details       = lookup(local.create_incident_grouping, "groupByCustomDetails", [])
       }
     }
   }


### PR DESCRIPTION
Update azurerm provider minimum version from 3.42 to 4.54 and refactor incident_configuration block to incident block per the azurerm 4.0 upgrade guide. This increases the entity_mapping limit from 5 to 10.

Other changes are due to https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/4.0-upgrade-guide#azurerm_sentinel_alert_rule_scheduled